### PR TITLE
Save/Restore extruder temperature on pause/resume

### DIFF
--- a/client.cfg
+++ b/client.cfg
@@ -80,12 +80,15 @@ gcode:
 description: Pause the actual running print
 rename_existing: PAUSE_BASE
 gcode:
+  SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=last_extruder_temp VALUE="{printer[printer.toolhead.extruder].target}"
+
   PAUSE_BASE
   _TOOLHEAD_PARK_PAUSE_CANCEL {rawparams}
 
 [gcode_macro RESUME]
 description: Resume the actual running print
 rename_existing: RESUME_BASE
+variable_last_extruder_temp: 0
 gcode:
   ##### get user parameters or use default #####
   {% set macro_found = True if printer['gcode_macro _CLIENT_VARIABLE'] is defined else False %}
@@ -93,6 +96,9 @@ gcode:
   {% set velocity = printer.configfile.settings.pause_resume.recover_velocity %}
   {% set sp_move        = velocity if not macro_found else client.speed_move|default(velocity) %}
   ##### end of definitions #####
+  SET_HEATER_TEMPERATURE HEATER=extruder TARGET={last_extruder_temp}
+  TEMPERATURE_WAIT SENSOR=extruder MINIMUM={last_extruder_temp*0.98} MAXIMUM={last_extruder_temp*1.02}
+
   _CLIENT_EXTRUDE
   RESUME_BASE VELOCITY={params.VELOCITY|default(sp_move)}
   


### PR DESCRIPTION
Possibility to cooldown the extruder on idle timeout or manually paused. On resume, the previous extruder temperature is set and wait for. If extruder temperature was not changed, nothing happens.

Signed-off-by: Frank Roth developer@freakydu.de